### PR TITLE
Publish angularAMD to npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# packaged angular-route
+# packaged angular-amd
 
 This repo is for distribution on `npm` and `bower`. The source for this module is in the
 [main angularAMD repo](https://github.com/marcoslin/angularAMD).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,55 @@
-# bower-angularAMD
-bower repo for angularAMD
+# packaged angular-route
 
+This repo is for distribution on `npm` and `bower`. The source for this module is in the
+[main angularAMD repo](https://github.com/marcoslin/angularAMD).
+
+## Install
+
+You can install this package either with `npm` or with `bower`.
+
+### npm
+
+```shell
+npm install angular-amd
+```
+
+### bower
+
+```shell
+bower install angularAMD
+```
+
+## Usage
+
+### Demo
+
+Demo is available on the
+[angularAMD docs](http://marcoslin.github.io/angularAMD/).
+
+### Sample App
+Additional, the following project has been created to illustrate how to build an r.js optmized distribution
+[angularAMD sample](https://github.com/marcoslin/angularAMD-sample).
+
+## License
+
+The MIT License
+
+Copyright (c) 2010-2015 Google, Inc. http://angularjs.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "Marcos Lin (https://github.com/marcoslin/)",
   "license": "MIT",
   "dependencies": {
-    "angular": "^1.4.7",
-    "requirejs": "^2.1.20"
-  }
+    "angular": "^1.3.0",
+    "requirejs": "~2.1.9"
+  },
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "angular-amd",
+  "version": "0.2.1",
+  "description": "Facilitate use of RequireJS in AngularJS",
+  "main": "angularAMD.js",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:marcoslin/bower-angularAMD.git"
+  },
+  "keywords": [
+    "angularjs",
+    "requirejs"
+  ],
+  "author": "Marcos Lin (https://github.com/marcoslin/)",
+  "license": "MIT",
+  "dependencies": {
+    "angular": "^1.4.7",
+    "requirejs": "^2.1.20"
+  }
+}


### PR DESCRIPTION
What has been done:
- Added package.json almost equal to bower.json. Only difference is the camelCase not accepted by npm.
- Improved README.md with angular repository pattern as bower-angular-route: https://github.com/angular/bower-angular-route
- I also have published to the repository node_modules

![selection_154](https://cloud.githubusercontent.com/assets/8049914/10990264/65a39ba8-8438-11e5-9a69-d87907ba1b00.png)
